### PR TITLE
feat: Add color code converter

### DIFF
--- a/.tanstack/tmp/fb2b3e45-f23383529c1a9c9b4b5c6902e0e3f178
+++ b/.tanstack/tmp/fb2b3e45-f23383529c1a9c9b4b5c6902e0e3f178
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/(tools)/color-code-converter')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/(tools)/color-code-converter"!</div>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,6 +2433,16 @@
         "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
+    "node_modules/@tanstack/react-router-devtools/node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@tanstack/react-router-devtools/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2461,6 +2471,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@tanstack/react-router-devtools/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tanstack/react-router-devtools/node_modules/vite": {
       "version": "7.2.2",
@@ -2605,6 +2622,16 @@
         }
       }
     },
+    "node_modules/@tanstack/router-devtools-core/node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@tanstack/router-devtools-core/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2633,6 +2660,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@tanstack/router-devtools-core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tanstack/router-devtools-core/node_modules/vite": {
       "version": "7.2.2",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as toolsImageCropperRouteImport } from './routes/(tools)/image-cr
 import { Route as toolsImageCompressorRouteImport } from './routes/(tools)/image-compressor'
 import { Route as toolsDiffCheckerRouteImport } from './routes/(tools)/diff-checker'
 import { Route as toolsColorPickerRouteImport } from './routes/(tools)/color-picker'
+import { Route as toolsColorCodeConverterRouteImport } from './routes/(tools)/color-code-converter'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -89,9 +90,15 @@ const toolsColorPickerRoute = toolsColorPickerRouteImport.update({
   path: '/color-picker',
   getParentRoute: () => rootRouteImport,
 } as any)
+const toolsColorCodeConverterRoute = toolsColorCodeConverterRouteImport.update({
+  id: '/(tools)/color-code-converter',
+  path: '/color-code-converter',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/color-code-converter': typeof toolsColorCodeConverterRoute
   '/color-picker': typeof toolsColorPickerRoute
   '/diff-checker': typeof toolsDiffCheckerRoute
   '/image-compressor': typeof toolsImageCompressorRoute
@@ -107,6 +114,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/color-code-converter': typeof toolsColorCodeConverterRoute
   '/color-picker': typeof toolsColorPickerRoute
   '/diff-checker': typeof toolsDiffCheckerRoute
   '/image-compressor': typeof toolsImageCompressorRoute
@@ -123,6 +131,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/(tools)/color-code-converter': typeof toolsColorCodeConverterRoute
   '/(tools)/color-picker': typeof toolsColorPickerRoute
   '/(tools)/diff-checker': typeof toolsDiffCheckerRoute
   '/(tools)/image-compressor': typeof toolsImageCompressorRoute
@@ -140,6 +149,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/color-code-converter'
     | '/color-picker'
     | '/diff-checker'
     | '/image-compressor'
@@ -155,6 +165,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/color-code-converter'
     | '/color-picker'
     | '/diff-checker'
     | '/image-compressor'
@@ -170,6 +181,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/(tools)/color-code-converter'
     | '/(tools)/color-picker'
     | '/(tools)/diff-checker'
     | '/(tools)/image-compressor'
@@ -186,6 +198,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  toolsColorCodeConverterRoute: typeof toolsColorCodeConverterRoute
   toolsColorPickerRoute: typeof toolsColorPickerRoute
   toolsDiffCheckerRoute: typeof toolsDiffCheckerRoute
   toolsImageCompressorRoute: typeof toolsImageCompressorRoute
@@ -293,11 +306,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof toolsColorPickerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/(tools)/color-code-converter': {
+      id: '/(tools)/color-code-converter'
+      path: '/color-code-converter'
+      fullPath: '/color-code-converter'
+      preLoaderRoute: typeof toolsColorCodeConverterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  toolsColorCodeConverterRoute: toolsColorCodeConverterRoute,
   toolsColorPickerRoute: toolsColorPickerRoute,
   toolsDiffCheckerRoute: toolsDiffCheckerRoute,
   toolsImageCompressorRoute: toolsImageCompressorRoute,

--- a/src/routes/(tools)/color-code-converter.tsx
+++ b/src/routes/(tools)/color-code-converter.tsx
@@ -1,0 +1,274 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react';
+
+import ContentLayout from '@/components/shared/content-layout'
+import { Input } from "@/components/ui/input";
+import { CopyButton } from "@/components/shared";
+
+export const Route = createFileRoute('/(tools)/color-code-converter')({
+  component: RouteComponent,
+})
+
+
+interface ColorValue {
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+}
+
+interface ColorConversion {
+  name: string;
+  toBase: (input: string) => ColorValue | null;
+  fromBase: (color: ColorValue) => string;
+  placeholder?: string;
+}
+
+
+// 'toBase' will convert to the base format will connects all colors {r,g,b,a}
+// 'fromBase' will convert from the base({r,g,b,a}) to any color format
+const colorFormats: Record<string, ColorConversion> = {
+  hex: {
+    name: "HEX",
+    placeholder: "Enter HEX Code (E.g.#FFFFFF or #666666)",
+    toBase: (input) => {
+      const hex = input.replace('#', '').trim();
+      if (hex.length !== 6 && hex.length !== 8) return null;
+      
+      const r = parseInt(hex.substring(0, 2), 16);
+      const g = parseInt(hex.substring(2, 4), 16);
+      const b = parseInt(hex.substring(4, 6), 16);
+      const a = hex.length === 8 ? Math.round((parseInt(hex.substring(6, 8), 16) / 255) * 100) / 100 : 1;
+      
+      return { r, g, b, a };
+    },
+    fromBase: (color) => {
+      const toHex = (n: number) => {
+        const hex = Math.round(n).toString(16);
+        return hex.length === 1 ? '0' + hex : hex;
+      };
+      
+      const hex = `#${toHex(color.r)}${toHex(color.g)}${toHex(color.b)}`;
+      if (color.a !== undefined && color.a < 1) {
+        return `${hex}${toHex(color.a * 255)}`;
+      }
+      return hex;
+    }
+  },
+  
+  rgb: {
+    name: "RGB/RGBA",
+    placeholder: "Enter Value (E.g rgb(255, 100, 100) or rgba(255, 100, 100, 0.5))",
+    toBase: (input) => {
+      const cleaned = input.replace(/\s+/g, '').toLowerCase();
+      const match = cleaned.match(/^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/);
+      
+      if (!match) return null;
+      
+      const r = parseInt(match[1]);
+      const g = parseInt(match[2]);
+      const b = parseInt(match[3]);
+      const a = match[4] ? Math.round(parseFloat(match[4]) * 100) / 100 : 1;
+      
+      if (r > 255 || g > 255 || b > 255 || a > 1) return null;
+      
+      return { r, g, b, a };
+    },
+    fromBase: (color) => {
+      if (color.a !== undefined && color.a < 1) {
+        const alphaRounded = Math.round(color.a * 100) / 100;
+        return `RGBA(${color.r}, ${color.g}, ${color.b}, ${alphaRounded})`;
+      }
+      return `RGB(${color.r}, ${color.g}, ${color.b})`;
+    }
+  },
+  hsl: {
+    name: "HSL/HSLA",
+    placeholder: "Enter Value (E.g hsl(120, 100%, 50%) or hsla(120, 100%, 50%, 0.5))",
+    toBase: (input) => {
+      const cleaned = input.replace(/\s+/g, '').toLowerCase();
+      const match = cleaned.match(/^hsla?\((\d+),(\d+)%,(\d+)%(?:,([\d.]+))?\)$/);
+      
+      if (!match) return null;
+      
+      const h = parseInt(match[1]) / 360;
+      const s = parseInt(match[2]) / 100;
+      const l = parseInt(match[3]) / 100;
+      const a = match[4] ? Math.round(parseFloat(match[4]) * 100) / 100 : 1;
+      
+      let r, g, b;
+      
+      if (s === 0) {
+        r = g = b = l;
+      } else {
+        const hue2rgb = (p: number, q: number, t: number) => {
+          if (t < 0) t += 1;
+          if (t > 1) t -= 1;
+          if (t < 1/6) return p + (q - p) * 6 * t;
+          if (t < 1/2) return q;
+          if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+          return p;
+        };
+        
+        const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        const p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1/3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1/3);
+      }
+      
+      return {
+        r: Math.round(r * 255),
+        g: Math.round(g * 255),
+        b: Math.round(b * 255),
+        a
+      };
+    },
+    fromBase: (color) => {
+      const r = color.r / 255;
+      const g = color.g / 255;
+      const b = color.b / 255;
+      
+      const max = Math.max(r, g, b);
+      const min = Math.min(r, g, b);
+      let h = 0, s = 0;
+      const l = (max + min) / 2;
+      
+      if (max !== min) {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        
+        switch (max) {
+          case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+          case g: h = ((b - r) / d + 2) / 6; break;
+          case b: h = ((r - g) / d + 4) / 6; break;
+        }
+      }
+      
+      const hDeg = Math.round(h * 360);
+      const sPercent = Math.round(s * 100);
+      const lPercent = Math.round(l * 100);
+      
+      if (color.a !== undefined && color.a < 1) {
+        const alphaRounded = Math.round(color.a * 100) / 100;
+        return `HSLA(${hDeg}, ${sPercent}%, ${lPercent}%, ${alphaRounded})`;
+      }
+      return `HSL(${hDeg}, ${sPercent}%, ${lPercent}%)`;
+    }
+  }
+};
+
+
+function RouteComponent() {
+  const [fromFormat, setFromFormat] = useState<string>(Object.keys(colorFormats)[0])
+  const [inputValue, setInputValue] = useState("")
+  const [results, setResults] = useState<Record<string, string>>({});
+
+
+   const handleConvert = (value: string, from: string) => {
+
+    if (!value) {
+      setResults({})
+      return;
+    }
+  
+    const baseValue = colorFormats[from].toBase(value)
+
+     if (!baseValue) {
+    setResults({});
+    return;
+  }
+
+    const converted: Record<string, string> = {};
+
+    Object.keys(colorFormats).forEach((key) => {
+      if (key !== from) {
+        converted[key] = colorFormats[key].fromBase(baseValue);
+      }
+    });
+
+    setResults(converted);
+  };
+
+  const handleFromFormatChange = (format: string) => {
+    setFromFormat(format);
+    setInputValue("")
+    setResults({})
+  };
+
+   const handleInputChange = (value: string) => {
+    setInputValue(value);
+    handleConvert(value, fromFormat);
+  };
+
+  return  <ContentLayout title="Color Code Converter">
+
+     <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-2">From:</label>
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+                  <Input
+                    type="text"
+                    value={inputValue}
+                    onChange={(e) => handleInputChange(e.target.value)}
+                    placeholder={colorFormats[fromFormat].placeholder}
+                    className="flex-1 text-base sm:text-lg py-4 sm:py-6"
+                  />
+                    <select
+                value={fromFormat}
+                onChange={(e) => handleFromFormatChange(e.target.value)}
+                className="px-4 py-3 sm:py-2 border-2 border-gray-300 rounded-lg text-sm sm:text-base font-medium focus:outline-none focus:border-black w-full sm:w-auto"
+              >
+                {Object.entries(colorFormats).map(([key, unit]) => (
+                  <option key={key} value={key}>
+                    {unit.name}
+                  </option>
+                ))}
+              </select>
+                  </div>
+
+
+
+                  </div>
+
+
+                   {/* Results Section */}
+          {Object.keys(results).length > 0 && (
+            <div className="space-y-3 mt-6">
+              <h3 className="text-base sm:text-lg font-semibold">
+                Converted Values:
+              </h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {Object.entries(results).map(([key, value]) => (
+                  <div
+                    key={key}
+                    className="p-3 sm:p-4 bg-gray-50 rounded-lg border-2 border-gray-200 hover:border-gray-300 transition-colors"
+                  >
+                    <div className="flex justify-between items-center gap-2">
+                      <span className="font-medium text-gray-700 text-sm sm:text-base truncate">
+                        {colorFormats[key].name}
+                      </span>
+                      <span className="text-base sm:text-lg font-bold text-black break-all text-right">
+                        {value}
+                      </span>
+                      <CopyButton textToCopy={value as string} variant="icon" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+
+          {!inputValue && (
+            <div className="text-center py-8 text-gray-400">
+              <p className="text-base sm:text-lg px-4">
+                Enter a value above to convert between different color formats.
+              </p>
+            </div>
+          )}
+
+                  </div>
+                  
+  </ContentLayout>
+}

--- a/src/routes/(tools)/color-code-converter.tsx
+++ b/src/routes/(tools)/color-code-converter.tsx
@@ -25,8 +25,6 @@ interface ColorConversion {
 }
 
 
-// 'toBase' will convert to the base format will connects all colors {r,g,b,a}
-// 'fromBase' will convert from the base({r,g,b,a}) to any color format
 const colorFormats: Record<string, ColorConversion> = {
   hex: {
     name: "HEX",
@@ -34,6 +32,8 @@ const colorFormats: Record<string, ColorConversion> = {
     toBase: (input) => {
       const hex = input.replace('#', '').trim();
       if (hex.length !== 6 && hex.length !== 8) return null;
+      
+      if (!/^[0-9A-Fa-f]+$/.test(hex)) return null;
       
       const r = parseInt(hex.substring(0, 2), 16);
       const g = parseInt(hex.substring(2, 4), 16);
@@ -94,7 +94,11 @@ const colorFormats: Record<string, ColorConversion> = {
       const h = parseInt(match[1]) / 360;
       const s = parseInt(match[2]) / 100;
       const l = parseInt(match[3]) / 100;
-      const a = match[4] ? Math.round(parseFloat(match[4]) * 100) / 100 : 1;
+      const a = match[4] ? parseFloat(match[4]) : 1;
+      
+      if (a < 0 || a > 1) return null;
+      
+      const alphaRounded = Math.round(a * 100) / 100;
       
       let r, g, b;
       
@@ -121,7 +125,7 @@ const colorFormats: Record<string, ColorConversion> = {
         r: Math.round(r * 255),
         g: Math.round(g * 255),
         b: Math.round(b * 255),
-        a
+        a: alphaRounded
       };
     },
     fromBase: (color) => {
@@ -202,7 +206,6 @@ function RouteComponent() {
   };
 
   return  <ContentLayout title="Color Code Converter">
-
      <div className="space-y-4">
               <div>
                 <label className="block text-sm font-medium mb-2">From:</label>
@@ -226,14 +229,9 @@ function RouteComponent() {
                 ))}
               </select>
                   </div>
-
-
-
                   </div>
 
-
-                   {/* Results Section */}
-          {Object.keys(results).length > 0 && (
+                   {Object.keys(results).length > 0 && (
             <div className="space-y-3 mt-6">
               <h3 className="text-base sm:text-lg font-semibold">
                 Converted Values:
@@ -258,8 +256,6 @@ function RouteComponent() {
               </div>
             </div>
           )}
-
-
           {!inputValue && (
             <div className="text-center py-8 text-gray-400">
               <p className="text-base sm:text-lg px-4">
@@ -268,7 +264,7 @@ function RouteComponent() {
             </div>
           )}
 
-                  </div>
+          </div>
                   
   </ContentLayout>
 }

--- a/src/tools.tsx
+++ b/src/tools.tsx
@@ -80,6 +80,12 @@ export default [
     category: "utility",
   },
   {
+    title: "Color Code Converter",
+    route: "/color-code-converter",
+    icon: SolarIconSet.RefreshCircle,
+    category: "image"
+  },
+  {
     title: "Password Generator",
     route: "/password-generator",
     icon: SolarIconSet.LockPassword,


### PR DESCRIPTION
- Added color code conversion logic in `(tools)/color-code-converter.tsx`
- Integrated it into the main tools page (`tools.tsx`)
- used the same styling as the unit converter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Color Code Converter tool that converts between HEX, RGB/RGBA, and HSL/HSLA. Available at /color-code-converter with real-time conversion and copy support.

- **New Features**
  - New route wired into TanStack Router and listed on the Tools page.
  - Conversion engine uses a base RGBA model with alpha handling and validation.
  - Supports HEX (#RRGGBB and #RRGGBBAA), RGB/RGBA, and HSL/HSLA formats.
  - Clean UI with input, format selector, results grid, and CopyButton.
  - Matches the unit converter styling.

<sup>Written for commit 5e71e022e5e4ff0e3599bc640136627c159e0117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

