### PR TITLE
Color palette feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
+        "@types/colorthief": "^2.6.0",
         "@types/nearest-color": "^0.4.1",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
@@ -99,6 +100,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -628,6 +630,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -651,6 +654,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2029,6 +2033,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.1.tgz",
       "integrity": "sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@svgr/babel-preset": "^6.5.1",
@@ -2391,6 +2396,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.135.2.tgz",
       "integrity": "sha512-IzvCJ5bZ4dTEh65J1NrILF3Ab+ajRgsHYQYl/3du1sptRfQkUSsRYQGXffQQU3JH++plmO/tJXtRTmgrAp4inA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.133.28",
         "@tanstack/react-store": "^0.8.0",
@@ -2455,12 +2461,20 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@tanstack/react-router-devtools/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@tanstack/react-router-devtools/node_modules/vite": {
       "version": "7.2.2",
@@ -2559,6 +2573,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.135.2.tgz",
       "integrity": "sha512-fhJSGmbqE78Ou6e+cnJ9exmjCzCZ9IXT2rApiPAgeItKj2yy1qmTEoR11n0x0fiNkkBxHL1us+QyG8JfNELiQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.133.28",
         "@tanstack/store": "^0.8.0",
@@ -2627,12 +2642,20 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@tanstack/router-devtools-core/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@tanstack/router-devtools-core/node_modules/vite": {
       "version": "7.2.2",
@@ -2836,6 +2859,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2980,6 +3004,13 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/colorthief": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@types/colorthief/-/colorthief-2.6.0.tgz",
+      "integrity": "sha512-GZBHPzkgEsyZqO7a9rhqkcW2BJZW+UpRlIUorY8vfOk7BVFVZMuDvZRPyaExv7ML0DaeB/t78PUOTkGo/THDpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3011,6 +3042,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3033,6 +3065,7 @@
       "integrity": "sha512-tBFxBp9Nfyy5rsmefN+WXc1JeW/j2BpBHFdLZbEVfs9wn3E3NRFxwV0pJg8M1qQAexFpvz73hJXFofV0ZAu92A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3043,6 +3076,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3401,6 +3435,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3811,7 +3846,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cwise-compiler": {
       "version": "1.1.3",
@@ -4710,6 +4746,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5530,6 +5567,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5539,6 +5577,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5850,6 +5889,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6181,7 +6221,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -6241,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6416,6 +6458,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -6435,6 +6478,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6532,6 +6576,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6646,6 +6691,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",
+    "@types/colorthief": "^2.6.0",
     "@types/nearest-color": "^0.4.1",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/src/components/shared/color-chip.tsx
+++ b/src/components/shared/color-chip.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib/utils";
+import { CopyButton, DeleteButton } from "@/components/shared";
+import { getLuminosity } from "@/utils/get-luminosity";
+
+type ColorChipProps = {
+    color: string;
+    onDelete?: () => void;
+    onClick?: () => void;
+    className?: string;
+    showCode?: boolean;
+    isSelected?: boolean;
+};
+
+export const ColorChip = ({ color, onDelete, onClick, className, showCode = true, isSelected = false }: ColorChipProps) => {
+
+    const textColor = getLuminosity(color) > 0.7 ? "#000000" : "#ffffff";
+
+    return (
+        <div
+            role="listitem"
+            aria-selected={isSelected}
+            className={cn(
+                "flex items-center justify-between rounded-lg p-3 shadow-sm transition hover:shadow-md min-h-12",
+                onClick ? "cursor-pointer hover:scale-[1.01]" : "",
+                isSelected ? "ring-2 ring-offset-2 ring-black/20" : "",
+                className
+            )}
+            style={{ backgroundColor: color }}
+            onClick={onClick}
+            tabIndex={onClick ? 0 : undefined}
+            onKeyDown={
+                onClick
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            onClick();
+                        }
+                    }
+                    : undefined
+            }
+        >
+            {/* Color code */}
+            {showCode && (
+                <span
+                    className="font-mono text-sm truncate"
+                    style={{ color: textColor }}
+                    title={color}
+                >
+                    {color}
+                </span>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 ml-2">
+                <CopyButton textToCopy={color} variant="icon" size="md" className="p-1" />
+                {onDelete && (
+                    <DeleteButton onClick={onDelete} variant="icon" size="md" className="p-1" />
+                )}
+            </div>
+        </div>
+    );
+};

--- a/src/components/shared/color-chip.tsx
+++ b/src/components/shared/color-chip.tsx
@@ -50,8 +50,8 @@ export const ColorChip = ({ color, onDelete, onClick, className, showCode = true
                 </span>
             )}
 
-            {/* Actions */}
-            <div className="flex items-center gap-2 ml-2">
+            {/* Actions (stop click bubbling to avoid selecting the chip when clicking an action) */}
+            <div className="flex items-center gap-2 ml-2" onClick={(e) => e.stopPropagation()}>
                 <CopyButton textToCopy={color} variant="icon" size="md" className="p-1" />
                 {onDelete && (
                     <DeleteButton onClick={onDelete} variant="icon" size="md" className="p-1" />

--- a/src/components/shared/color-code-list.tsx
+++ b/src/components/shared/color-code-list.tsx
@@ -1,0 +1,23 @@
+import { CopyButton } from "@/components/shared";
+
+type ColorCodeListProps = {
+    entries: Record<string, string | number>;
+};
+
+export const ColorCodeList = ({ entries }: ColorCodeListProps) => {
+    return (
+        <div className="space-y-3">
+            {Object.entries(entries)
+                .filter(([key]) => key !== "name")
+                .map(([key, value]) => (
+                    <div key={key} className="flex items-center justify-between gap-4 p-3 bg-gray-50 rounded-lg">
+                        <div className="flex items-center gap-3 flex-1 min-w-0">
+                            <p className="uppercase font-medium text-sm w-16">{key}</p>
+                            <p className="text-sm font-mono truncate">{String(value)}</p>
+                        </div>
+                        <CopyButton textToCopy={String(value)} variant="icon" />
+                    </div>
+                ))}
+        </div>
+    );
+}

--- a/src/components/shared/delete-button.tsx
+++ b/src/components/shared/delete-button.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Trash, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type DeleteButtonProps = {
+    onClick: () => void;
+    className?: string;
+    variant?: "default" | "icon" | "minimal";
+    size?: "sm" | "md" | "lg";
+    showLabel?: boolean;
+    disabled?: boolean;
+    label?: string;
+};
+
+export const DeleteButton = ({
+    onClick,
+    className = "",
+    variant = "default",
+    size = "md",
+    showLabel = true,
+    disabled = false,
+    label = "Delete",
+}: DeleteButtonProps) => {
+    const sizeClasses = {
+        sm: "py-1 px-2 text-xs",
+        md: "py-2 px-3 text-sm",
+        lg: "py-2 px-4 text-base",
+    };
+
+    const iconSizes = {
+        sm: 14,
+        md: 16,
+        lg: 18,
+    };
+
+    if (variant === "icon") {
+        return (
+            <button
+                onClick={onClick}
+                disabled={disabled}
+                className={`p-2 transition-colors rounded-lg bg-gray-600 hover:bg-gray-700 text-white disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+                title={label}
+                aria-label={label}
+            >
+                <Trash size={iconSizes[size]} />
+            </button>
+        );
+    }
+
+    if (variant === "minimal") {
+        return (
+            <button
+                onClick={onClick}
+                disabled={disabled}
+                className={`flex items-center gap-2 transition-colors text-gray-700 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+                aria-label={label}
+            >
+                <Trash size={iconSizes[size]} />
+                {showLabel && <span className="text-sm">{label}</span>}
+            </button>
+        );
+    }
+
+    return (
+        <Button
+            onClick={onClick}
+            disabled={disabled}
+            className={`flex items-center justify-center gap-2 ${sizeClasses[size]} min-w-[90px] overflow-hidden relative transition-colors bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+        >
+            <Trash size={iconSizes[size]} />
+            {showLabel && label}
+        </Button>
+    );
+};

--- a/src/components/shared/index.tsx
+++ b/src/components/shared/index.tsx
@@ -15,3 +15,6 @@ export { ActionBar } from "./action-bar";
 export { PresetSelector } from "./preset-selector";
 export { ResultCard } from "./result-card";
 export { ButtonGroup } from "./button-group";
+export { ColorChip } from "./color-chip";
+export { ColorCodeList } from "./color-code-list";
+export { DeleteButton } from "./delete-button";

--- a/src/routes/(tools)/color-picker.tsx
+++ b/src/routes/(tools)/color-picker.tsx
@@ -84,7 +84,16 @@ function RouteComponent() {
     };
 
     const removeFromPalette = (idx: number) => {
-        setPalette((prev) => prev.filter((_, i) => i !== idx));
+        setPalette((prev) => {
+            const next = prev.filter((_, i) => i !== idx);
+            setSelectedPaletteIndex((cur) => {
+                if (cur === null) return null;
+                if (cur === idx) return null;
+                if (cur > idx) return cur - 1;
+                return cur;
+            });
+            return next;
+        });
     };
 
     return (

--- a/src/routes/(tools)/color-picker.tsx
+++ b/src/routes/(tools)/color-picker.tsx
@@ -1,80 +1,170 @@
-import ContentLayout from "@/components/shared/content-layout";
-import { createFileRoute } from "@tanstack/react-router";
 import iro from "@jaames/iro";
+
 import { useEffect, useRef, useState } from "react";
-import { convertHexColorCode } from "@/utils/convert-hex-color-code";
 import { getLuminosity } from "@/utils/get-luminosity";
-import { CopyButton } from "@/components/shared";
+import { createFileRoute } from "@tanstack/react-router";
+import { ColorChip, ColorCodeList } from "@/components/shared";
+import ContentLayout from "@/components/shared/content-layout";
+import { convertHexColorCode } from "@/utils/convert-hex-color-code";
 
 export const Route = createFileRoute("/(tools)/color-picker")({
-  component: RouteComponent,
+    component: RouteComponent,
 });
 
 function RouteComponent() {
-  const colorPickerRef = useRef<HTMLDivElement>(null);
-  const [color, setColor] = useState("#f00");
-  const [colorCode, setColorCode] = useState(convertHexColorCode(color));
+    // Default Config
+    const paletteSize = 5;
+    const [color, setColor] = useState('#fff');
 
-  useEffect(() => {
-    const container = colorPickerRef.current;
-    if (container) {
-      container.innerHTML = "";
+    const colorPickerRef = useRef<HTMLDivElement>(null);
+    const colorPickerInstance = useRef<iro.ColorPicker | null>(null);
 
-      // Determine size based on screen width
-      const getPickerWidth = () => {
-        if (window.innerWidth < 640)
-          return Math.min(window.innerWidth - 32, 280);
-        if (window.innerWidth < 1024) return 350;
-        return 500;
-      };
+    const [colorCode, setColorCode] = useState(convertHexColorCode(color));
+    const [palette, setPalette] = useState<string[]>([]);
+    const [selectedPaletteIndex, setSelectedPaletteIndex] = useState<number | null>(null);
 
-      // @ts-ignore
-      const colorPicker = new iro.ColorPicker(container, {
-        width: getPickerWidth(),
-        color: color,
-      });
+    useEffect(() => {
+        const container = colorPickerRef.current;
+        if (container) {
+            container.innerHTML = "";
 
-      colorPicker.on("color:change", (color: iro.Color) => {
-        setColor(color.hexString);
-        setColorCode(convertHexColorCode(color.hexString));
-      });
-    }
-  }, []);
+            // Determine size based on screen width
+            const getPickerWidth = () => {
+                if (window.innerWidth < 640)
+                    return Math.min(window.innerWidth - 32, 280);
+                if (window.innerWidth < 1024) return 350;
+                return 500;
+            };
 
-  return (
-    <ContentLayout title="Color Picker">
-      <div className="flex flex-col lg:flex-row gap-8 lg:gap-20 w-full">
-        <div ref={colorPickerRef} className="w-fit mx-auto lg:mx-0" />
-        <div className="w-full">
-          <div
-            className="h-24 lg:h-20 w-full rounded-lg flex items-center justify-center mb-6"
-            style={{
-              backgroundColor: color,
-              color: getLuminosity(color) > 0.5 ? "black" : "white",
-            }}
-          >
-            <p className="text-lg lg:text-xl font-semibold px-4 text-center">
-              {colorCode.name}
-            </p>
-          </div>
-          <div className="space-y-3">
-            {Object.entries(colorCode)
-              .filter(([key]) => key !== "name")
-              .map(([key, value]) => (
-                <div
-                  key={key}
-                  className="flex items-center justify-between gap-4 p-3 bg-gray-50 rounded-lg"
-                >
-                  <div className="flex items-center gap-3 flex-1 min-w-0">
-                    <p className="uppercase font-medium text-sm w-16">{key}</p>
-                    <p className="text-sm font-mono truncate">{value}</p>
-                  </div>
-                  <CopyButton textToCopy={value as string} variant="icon" />
+            // @ts-ignore
+            const colorPicker = new iro.ColorPicker(container, {
+                width: getPickerWidth(),
+                color: color,
+            });
+
+            colorPicker.on("color:change", (color: iro.Color) => {
+                setColor(color.hexString);
+                setColorCode(convertHexColorCode(color.hexString));
+            });
+
+            colorPickerInstance.current = colorPicker;
+
+            // Auto-generate a color
+            autoGenerateColor();
+        }
+    }, []);
+
+    const autoGenerateColor = () => {
+        // Generate a random hex color
+        const r = Math.floor(Math.random() * 256)
+            .toString(16)
+            .padStart(2, "0");
+        const g = Math.floor(Math.random() * 256)
+            .toString(16)
+            .padStart(2, "0");
+        const b = Math.floor(Math.random() * 256)
+            .toString(16)
+            .padStart(2, "0");
+        const hex = `#${r}${g}${b}`;
+
+        setColor(hex);
+        setColorCode(convertHexColorCode(hex));
+        // If the picker instance exists, update it immediately
+        if (colorPickerInstance.current) {
+            colorPickerInstance.current.color.set(hex);
+        }
+    };
+
+    const addToPalette = () => {
+        setPalette((prev) => {
+            if (prev.length >= paletteSize) return prev;
+            if (prev.includes(color)) return prev;
+            return [...prev, color];
+        });
+    };
+
+    const removeFromPalette = (idx: number) => {
+        setPalette((prev) => prev.filter((_, i) => i !== idx));
+    };
+
+    return (
+        <ContentLayout title="Color Picker">
+            <div className="flex flex-col lg:flex-row gap-8 lg:gap-20 w-full">
+                {/* COLOR PICKER HTML REFERENCE */}
+                <div ref={colorPickerRef} className="w-fit mx-auto lg:mx-0" />
+
+                <div className="w-full">
+                    <div
+                        className="h-24 lg:h-20 w-full rounded-lg flex items-center justify-center mb-4"
+                        style={{
+                            backgroundColor: color,
+                            color: getLuminosity(color) > 0.7 ? "black" : "white",
+                        }}
+                    >
+                        <p className="text-lg lg:text-xl font-semibold px-4 text-center">
+                            {colorCode.name}
+                        </p>
+                    </div>
+
+                    {/* Color codes */}
+                    <ColorCodeList entries={colorCode as Record<string, string | number>} />
+
+                    <div className="mt-3">
+                        {/* Actions */}
+                        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 mb-6">
+                            <button
+                                type="button"
+                                className="w-full sm:w-auto px-3 py-2 rounded bg-black text-white text-sm hover:opacity-90"
+                                onClick={autoGenerateColor}
+                                aria-label="Auto generate a random color"
+                            >
+                                Auto Generate
+                            </button>
+                            <button
+                                type="button"
+                                className="w-full sm:w-auto px-3 py-2 rounded border border-gray-300 text-sm hover:bg-gray-100"
+                                onClick={addToPalette}
+                                disabled={palette.length >= paletteSize}
+                                aria-label="Add current color to palette"
+                            >
+                                Add to Palette ({palette.length}/{paletteSize})
+                            </button>
+                        </div>
+
+                        <p className="text-xs text-gray-500 mb-4">
+                            Tip: this tool auto-generates a color on load, click a swatch to view its codes, or use the copy button to copy any value. Palette capped at {paletteSize} colors.
+                        </p>
+
+                        {/* Palette */}
+                        <div role="list" aria-label="Palette" className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-8">
+                            {palette.map((p, idx) => (
+                                <ColorChip
+                                    key={p}
+                                    color={p}
+                                    onDelete={() => removeFromPalette(idx)}
+                                    onClick={() =>
+                                        setSelectedPaletteIndex((cur) => (cur === idx ? null : idx))
+                                    }
+                                    isSelected={selectedPaletteIndex === idx}
+                                />
+                            ))}
+                            {palette.length === 0 && (
+                                <p className="text-sm text-gray-500">Palette empty!</p>
+                            )}
+                        </div>
+
+                        {/* Selected palette color codes */}
+                        {selectedPaletteIndex !== null && palette[selectedPaletteIndex] && (
+                            <div className="mt-4">
+                                <p className="text-sm font-medium mb-2">Palette color</p>
+                                <ColorCodeList
+                                    entries={convertHexColorCode(palette[selectedPaletteIndex]) as Record<string, string | number>}
+                                />
+                            </div>
+                        )}
+                    </div>
                 </div>
-              ))}
-          </div>
-        </div>
-      </div>
-    </ContentLayout>
-  );
+            </div>
+        </ContentLayout>
+    );
 }

--- a/src/routes/(tools)/image-palette-generator.tsx
+++ b/src/routes/(tools)/image-palette-generator.tsx
@@ -2,7 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon, X, ChevronDown } from "lucide-react";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { AnimatePresence, motion } from "motion/react";
-// @ts-ignore
 import ColorThief from "colorthief";
 import Modal from "@/components/shared/modal";
 import { convertHexColorCode } from "@/utils/convert-hex-color-code";
@@ -10,146 +9,146 @@ import { getLuminosity } from "@/utils/get-luminosity";
 import { Tooltip } from "react-tooltip";
 import ContentLayout from "@/components/shared/content-layout";
 import {
-  FileDropZone,
-  ColorCard,
-  EmptyState,
-  LoadingSpinner,
+    FileDropZone,
+    ColorCard,
+    EmptyState,
+    LoadingSpinner,
 } from "@/components/shared";
 
 export const Route = createFileRoute("/(tools)/image-palette-generator")({
-  component: RouteComponent,
+    component: RouteComponent,
 });
 
 type ExportFormat = "json" | "css" | "scss" | "tailwind" | "array";
 
 function RouteComponent() {
-  const [image, setImage] = useState<string | null>(null);
-  const [colors, setColors] = useState<string[]>([]);
-  const [fullPalette, setFullPalette] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedColor, setSelectedColor] = useState<string | null>(null);
-  const [showExportMenu, setShowExportMenu] = useState(false);
-  const exportMenuRef = useRef<HTMLDivElement>(null);
+    const [image, setImage] = useState<string | null>(null);
+    const [colors, setColors] = useState<string[]>([]);
+    const [fullPalette, setFullPalette] = useState<string[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedColor, setSelectedColor] = useState<string | null>(null);
+    const [showExportMenu, setShowExportMenu] = useState(false);
+    const exportMenuRef = useRef<HTMLDivElement>(null);
 
-  const extractColors = useCallback(
-    (src: string) => {
-      if (loading) return;
+    const extractColors = useCallback(
+        (src: string) => {
+            if (loading) return;
 
-      setLoading(true);
-      const img = new Image();
-      img.crossOrigin = "Anonymous";
-      img.src = src;
+            setLoading(true);
+            const img = new Image();
+            img.crossOrigin = "Anonymous";
+            img.src = src;
 
-      img.onload = () => {
-        try {
-          const colorThief = new ColorThief();
-          const palette = colorThief.getPalette(img, 10) as [
-            number,
-            number,
-            number,
-          ][];
-          const hexColors = palette.map(
-            ([r, g, b]) =>
-              `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`,
-          );
-          setFullPalette(hexColors);
-          setColors(hexColors.slice(0, 6));
-        } catch (err) {
-          console.error("Failed to extract palette:", err);
-          setFullPalette([]);
-          setColors([]);
-        } finally {
-          setLoading(false);
+            img.onload = () => {
+                try {
+                    const colorThief = new ColorThief();
+                    const palette = colorThief.getPalette(img, 10) as [
+                        number,
+                        number,
+                        number,
+                    ][];
+                    const hexColors = palette.map(
+                        ([r, g, b]) =>
+                            `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`,
+                    );
+                    setFullPalette(hexColors);
+                    setColors(hexColors.slice(0, 6));
+                } catch (err) {
+                    console.error("Failed to extract palette:", err);
+                    setFullPalette([]);
+                    setColors([]);
+                } finally {
+                    setLoading(false);
+                }
+            };
+
+            img.onerror = () => {
+                console.error("Image failed to load.");
+                setLoading(false);
+            };
+        },
+        [loading],
+    );
+
+    const handleFileSelect = (file: File) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result as string;
+            setImage(result);
+            extractColors(result);
+        };
+        reader.readAsDataURL(file);
+    };
+
+    const addNewColor = () => {
+        if (colors.length < fullPalette.length) {
+            setColors((prev) => [...prev, fullPalette[prev.length]]);
         }
-      };
-
-      img.onerror = () => {
-        console.error("Image failed to load.");
-        setLoading(false);
-      };
-    },
-    [loading],
-  );
-
-  const handleFileSelect = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      setImage(result);
-      extractColors(result);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const addNewColor = () => {
-    if (colors.length < fullPalette.length) {
-      setColors((prev) => [...prev, fullPalette[prev.length]]);
-    }
-  };
-
-  const convertedColor = useMemo(() => {
-    if (!isModalOpen || !selectedColor) return null;
-    if (!/^#[0-9A-Fa-f]{6}$/.test(selectedColor)) return null;
-
-    return convertHexColorCode(selectedColor);
-  }, [isModalOpen, selectedColor]);
-
-  const textColor =
-    getLuminosity(selectedColor || "") > 0.5 ? "black" : "white";
-
-  // Close export menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        exportMenuRef.current &&
-        !exportMenuRef.current.contains(event.target as Node)
-      ) {
-        setShowExportMenu(false);
-      }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+    const convertedColor = useMemo(() => {
+        if (!isModalOpen || !selectedColor) return null;
+        if (!/^#[0-9A-Fa-f]{6}$/.test(selectedColor)) return null;
 
-  const exportPalette = (format: ExportFormat) => {
-    let content = "";
-    let filename = "";
-    let mimeType = "text/plain";
+        return convertHexColorCode(selectedColor);
+    }, [isModalOpen, selectedColor]);
 
-    switch (format) {
-      case "json":
-        content = JSON.stringify({ colors }, null, 2);
-        filename = "palette.json";
-        mimeType = "application/json";
-        break;
+    const textColor =
+        getLuminosity(selectedColor || "") > 0.5 ? "black" : "white";
 
-      case "css":
-        content = `:root {
+    // Close export menu when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                exportMenuRef.current &&
+                !exportMenuRef.current.contains(event.target as Node)
+            ) {
+                setShowExportMenu(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+    const exportPalette = (format: ExportFormat) => {
+        let content = "";
+        let filename = "";
+        let mimeType = "text/plain";
+
+        switch (format) {
+            case "json":
+                content = JSON.stringify({ colors }, null, 2);
+                filename = "palette.json";
+                mimeType = "application/json";
+                break;
+
+            case "css":
+                content = `:root {
 ${colors.map((color, i) => `  --color-${i + 1}: ${color};`).join("\n")}
 }`;
-        filename = "palette.css";
-        mimeType = "text/css";
-        break;
+                filename = "palette.css";
+                mimeType = "text/css";
+                break;
 
-      case "scss":
-        content = colors
-          .map((color, i) => `$color-${i + 1}: ${color};`)
-          .join("\n");
-        filename = "palette.scss";
-        mimeType = "text/plain";
-        break;
+            case "scss":
+                content = colors
+                    .map((color, i) => `$color-${i + 1}: ${color};`)
+                    .join("\n");
+                filename = "palette.scss";
+                mimeType = "text/plain";
+                break;
 
-      case "tailwind":
-        const tailwindColors = colors.reduce(
-          (acc, color, i) => {
-            acc[`palette-${i + 1}`] = color;
-            return acc;
-          },
-          {} as Record<string, string>,
-        );
-        content = `// Add to your tailwind.config.js
+            case "tailwind":
+                const tailwindColors = colors.reduce(
+                    (acc, color, i) => {
+                        acc[`palette-${i + 1}`] = color;
+                        return acc;
+                    },
+                    {} as Record<string, string>,
+                );
+                content = `// Add to your tailwind.config.js
 module.exports = {
   theme: {
     extend: {
@@ -157,234 +156,234 @@ module.exports = {
     }
   }
 }`;
-        filename = "tailwind-colors.js";
-        mimeType = "text/javascript";
-        break;
+                filename = "tailwind-colors.js";
+                mimeType = "text/javascript";
+                break;
 
-      case "array":
-        content = `const palette = ${JSON.stringify(colors, null, 2)};`;
-        filename = "palette.js";
-        mimeType = "text/javascript";
-        break;
-    }
+            case "array":
+                content = `const palette = ${JSON.stringify(colors, null, 2)};`;
+                filename = "palette.js";
+                mimeType = "text/javascript";
+                break;
+        }
 
-    // Create and download the file
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-    setShowExportMenu(false);
-  };
+        // Create and download the file
+        const blob = new Blob([content], { type: mimeType });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        setShowExportMenu(false);
+    };
 
-  const copyAllColors = () => {
-    navigator.clipboard.writeText(colors.join(", "));
-    setShowExportMenu(false);
-  };
+    const copyAllColors = () => {
+        navigator.clipboard.writeText(colors.join(", "));
+        setShowExportMenu(false);
+    };
 
-  return (
-    <>
-      <Modal
-        isOpen={isModalOpen && !!selectedColor}
-        onClose={() => setIsModalOpen(false)}
-        title="Color Details"
-      >
-        <Tooltip id="tooltip" />
+    return (
+        <>
+            <Modal
+                isOpen={isModalOpen && !!selectedColor}
+                onClose={() => setIsModalOpen(false)}
+                title="Color Details"
+            >
+                <Tooltip id="tooltip" />
 
-        <div className="space-y-3">
-          {convertedColor &&
-            Object.entries(convertedColor).map(([key, value]) => (
-              <div
-                key={key}
-                className="w-full h-14 rounded-lg flex items-center justify-between px-5 uppercase font-medium cursor-pointer hover:scale-[1.02] transition-transform"
-                style={{ backgroundColor: selectedColor!, color: textColor }}
-                data-tooltip-id="tooltip"
-                data-tooltip-content="Click to copy"
-                onClick={() => {
-                  navigator.clipboard.writeText(value);
-                }}
-              >
-                <p className="font-semibold">{key}</p>
-                <p className="font-mono">{value}</p>
-              </div>
-            ))}
-        </div>
-      </Modal>
-      <ContentLayout title="Image Palette Generator">
-        <div className="flex flex-col lg:flex-row gap-6">
-          {/* Upload Section */}
-          <div className="w-full lg:w-[60%]">
-            {!image ? (
-              <FileDropZone
-                onFileSelect={handleFileSelect}
-                accept={{ "image/*": [] }}
-                loading={loading}
-                height="h-[600px]"
-              />
-            ) : (
-              <div className="w-full border-2 border-dashed border-gray-300 h-[600px] rounded-xl flex items-center justify-center relative overflow-hidden">
-                <button
-                  onClick={() => {
-                    setImage(null);
-                    setColors([]);
-                    setFullPalette([]);
-                  }}
-                  className="absolute top-4 right-4 size-9 flex items-center justify-center bg-white hover:bg-red-50 text-red-600 transition-colors rounded-lg shadow-md z-10"
-                >
-                  <X size={20} />
-                </button>
-                {loading ? (
-                  <LoadingSpinner
-                    size="lg"
-                    message="Extracting colors..."
-                    submessage="Please wait"
-                  />
-                ) : (
-                  <img
-                    src={image}
-                    alt="Uploaded Preview"
-                    className="max-h-full max-w-full object-contain rounded-xl"
-                  />
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Palette Section */}
-          <div className="w-full lg:w-[40%]">
-            <div className="flex flex-col gap-y-4 h-full">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-2xl font-bold text-gray-900">
-                    Color Palette
-                  </p>
-                  <p className="text-sm text-gray-500 mt-1">
-                    {colors.length > 0
-                      ? `${colors.length} colors extracted`
-                      : "Upload an image to get started"}
-                  </p>
+                <div className="space-y-3">
+                    {convertedColor &&
+                        Object.entries(convertedColor).map(([key, value]) => (
+                            <div
+                                key={key}
+                                className="w-full h-14 rounded-lg flex items-center justify-between px-5 uppercase font-medium cursor-pointer hover:scale-[1.02] transition-transform"
+                                style={{ backgroundColor: selectedColor!, color: textColor }}
+                                data-tooltip-id="tooltip"
+                                data-tooltip-content="Click to copy"
+                                onClick={() => {
+                                    navigator.clipboard.writeText(value);
+                                }}
+                            >
+                                <p className="font-semibold">{key}</p>
+                                <p className="font-mono">{value}</p>
+                            </div>
+                        ))}
                 </div>
-                {colors.length > 0 && (
-                  <div className="flex gap-x-px relative" ref={exportMenuRef}>
-                    <button
-                      className="bg-black text-white px-4 py-2.5 rounded-l-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-800 transition-colors font-medium text-sm"
-                      disabled={colors.length === 0}
-                      onClick={copyAllColors}
-                    >
-                      Copy All
-                    </button>
-                    <button
-                      className="bg-black text-white px-2.5 py-2.5 rounded-r-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-800 transition-colors"
-                      disabled={colors.length === 0}
-                      onClick={() => setShowExportMenu(!showExportMenu)}
-                    >
-                      <ChevronDown size={18} />
-                    </button>
+            </Modal>
+            <ContentLayout title="Image Palette Generator">
+                <div className="flex flex-col lg:flex-row gap-6">
+                    {/* Upload Section */}
+                    <div className="w-full lg:w-[60%]">
+                        {!image ? (
+                            <FileDropZone
+                                onFileSelect={handleFileSelect}
+                                accept={{ "image/*": [] }}
+                                loading={loading}
+                                height="h-[600px]"
+                            />
+                        ) : (
+                            <div className="w-full border-2 border-dashed border-gray-300 h-[600px] rounded-xl flex items-center justify-center relative overflow-hidden">
+                                <button
+                                    onClick={() => {
+                                        setImage(null);
+                                        setColors([]);
+                                        setFullPalette([]);
+                                    }}
+                                    className="absolute top-4 right-4 size-9 flex items-center justify-center bg-white hover:bg-red-50 text-red-600 transition-colors rounded-lg shadow-md z-10"
+                                >
+                                    <X size={20} />
+                                </button>
+                                {loading ? (
+                                    <LoadingSpinner
+                                        size="lg"
+                                        message="Extracting colors..."
+                                        submessage="Please wait"
+                                    />
+                                ) : (
+                                    <img
+                                        src={image}
+                                        alt="Uploaded Preview"
+                                        className="max-h-full max-w-full object-contain rounded-xl"
+                                    />
+                                )}
+                            </div>
+                        )}
+                    </div>
 
-                    {/* Export Menu Dropdown */}
-                    <AnimatePresence>
-                      {showExportMenu && (
-                        <motion.div
-                          initial={{ opacity: 0, y: -10 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={{ opacity: 0, y: -10 }}
-                          transition={{ duration: 0.2 }}
-                          className="absolute top-full right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden z-20"
-                        >
-                          <div className="py-1">
-                            <button
-                              onClick={() => exportPalette("json")}
-                              className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
-                            >
-                              Export as JSON
-                            </button>
-                            <button
-                              onClick={() => exportPalette("css")}
-                              className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
-                            >
-                              Export as CSS
-                            </button>
-                            <button
-                              onClick={() => exportPalette("scss")}
-                              className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
-                            >
-                              Export as SCSS
-                            </button>
-                            <button
-                              onClick={() => exportPalette("tailwind")}
-                              className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
-                            >
-                              Export for Tailwind
-                            </button>
-                            <button
-                              onClick={() => exportPalette("array")}
-                              className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
-                            >
-                              Export as Array
-                            </button>
-                          </div>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
-                  </div>
-                )}
-              </div>
+                    {/* Palette Section */}
+                    <div className="w-full lg:w-[40%]">
+                        <div className="flex flex-col gap-y-4 h-full">
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <p className="text-2xl font-bold text-gray-900">
+                                        Color Palette
+                                    </p>
+                                    <p className="text-sm text-gray-500 mt-1">
+                                        {colors.length > 0
+                                            ? `${colors.length} colors extracted`
+                                            : "Upload an image to get started"}
+                                    </p>
+                                </div>
+                                {colors.length > 0 && (
+                                    <div className="flex gap-x-px relative" ref={exportMenuRef}>
+                                        <button
+                                            className="bg-black text-white px-4 py-2.5 rounded-l-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-800 transition-colors font-medium text-sm"
+                                            disabled={colors.length === 0}
+                                            onClick={copyAllColors}
+                                        >
+                                            Copy All
+                                        </button>
+                                        <button
+                                            className="bg-black text-white px-2.5 py-2.5 rounded-r-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-800 transition-colors"
+                                            disabled={colors.length === 0}
+                                            onClick={() => setShowExportMenu(!showExportMenu)}
+                                        >
+                                            <ChevronDown size={18} />
+                                        </button>
 
-              <div className="flex flex-col gap-y-3 flex-1">
-                {colors.length === 0 && !loading && (
-                  <EmptyState
-                    icon={<PlusIcon size={32} className="opacity-50" />}
-                    title="No colors yet"
-                    description="Upload an image to extract its color palette"
-                    className="border-2 border-dashed border-gray-300 rounded-xl h-[545px]"
-                  />
-                )}
+                                        {/* Export Menu Dropdown */}
+                                        <AnimatePresence>
+                                            {showExportMenu && (
+                                                <motion.div
+                                                    initial={{ opacity: 0, y: -10 }}
+                                                    animate={{ opacity: 1, y: 0 }}
+                                                    exit={{ opacity: 0, y: -10 }}
+                                                    transition={{ duration: 0.2 }}
+                                                    className="absolute top-full right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden z-20"
+                                                >
+                                                    <div className="py-1">
+                                                        <button
+                                                            onClick={() => exportPalette("json")}
+                                                            className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                                                        >
+                                                            Export as JSON
+                                                        </button>
+                                                        <button
+                                                            onClick={() => exportPalette("css")}
+                                                            className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                                                        >
+                                                            Export as CSS
+                                                        </button>
+                                                        <button
+                                                            onClick={() => exportPalette("scss")}
+                                                            className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                                                        >
+                                                            Export as SCSS
+                                                        </button>
+                                                        <button
+                                                            onClick={() => exportPalette("tailwind")}
+                                                            className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                                                        >
+                                                            Export for Tailwind
+                                                        </button>
+                                                        <button
+                                                            onClick={() => exportPalette("array")}
+                                                            className="w-full text-left px-4 py-2.5 hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                                                        >
+                                                            Export as Array
+                                                        </button>
+                                                    </div>
+                                                </motion.div>
+                                            )}
+                                        </AnimatePresence>
+                                    </div>
+                                )}
+                            </div>
 
-                <AnimatePresence>
-                  {colors.map((color, index) => (
-                    <motion.div
-                      key={color}
-                      initial={{ opacity: 0, y: 10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -10 }}
-                      transition={{ duration: 0.3 }}
-                    >
-                      <ColorCard
-                        color={color}
-                        showCopyButton={false}
-                        onClick={() => {
-                          setIsModalOpen(true);
-                          setSelectedColor(color);
-                        }}
-                        className="cursor-pointer hover:border-black hover:shadow-md transition-all h-16"
-                      />
-                    </motion.div>
-                  ))}
-                </AnimatePresence>
+                            <div className="flex flex-col gap-y-3 flex-1">
+                                {colors.length === 0 && !loading && (
+                                    <EmptyState
+                                        icon={<PlusIcon size={32} className="opacity-50" />}
+                                        title="No colors yet"
+                                        description="Upload an image to extract its color palette"
+                                        className="border-2 border-dashed border-gray-300 rounded-xl h-[545px]"
+                                    />
+                                )}
 
-                {!!image && colors.length > 0 && (
-                  <button
-                    className="text-sm bg-gray-100 hover:bg-gray-200 transition-colors w-full py-3 rounded-lg flex items-center justify-center gap-x-2 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed font-medium border border-gray-200"
-                    onClick={addNewColor}
-                    disabled={
-                      colors.length >= fullPalette.length || loading || !image
-                    }
-                  >
-                    <PlusIcon size={18} />
-                    {colors.length >= fullPalette.length
-                      ? "All colors extracted"
-                      : "Add Another Color"}
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </ContentLayout>
-    </>
-  );
+                                <AnimatePresence>
+                                    {colors.map((color, index) => (
+                                        <motion.div
+                                            key={color}
+                                            initial={{ opacity: 0, y: 10 }}
+                                            animate={{ opacity: 1, y: 0 }}
+                                            exit={{ opacity: 0, y: -10 }}
+                                            transition={{ duration: 0.3 }}
+                                        >
+                                            <ColorCard
+                                                color={color}
+                                                showCopyButton={false}
+                                                onClick={() => {
+                                                    setIsModalOpen(true);
+                                                    setSelectedColor(color);
+                                                }}
+                                                className="cursor-pointer hover:border-black hover:shadow-md transition-all h-16"
+                                            />
+                                        </motion.div>
+                                    ))}
+                                </AnimatePresence>
+
+                                {!!image && colors.length > 0 && (
+                                    <button
+                                        className="text-sm bg-gray-100 hover:bg-gray-200 transition-colors w-full py-3 rounded-lg flex items-center justify-center gap-x-2 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed font-medium border border-gray-200"
+                                        onClick={addNewColor}
+                                        disabled={
+                                            colors.length >= fullPalette.length || loading || !image
+                                        }
+                                    >
+                                        <PlusIcon size={18} />
+                                        {colors.length >= fullPalette.length
+                                            ? "All colors extracted"
+                                            : "Add Another Color"}
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </ContentLayout>
+        </>
+    );
 }


### PR DESCRIPTION
Extends the Color Picker with: auto-generate color and add-to-palette feature, selectable palette chips that show a color’s code list, and small UI hints.

Testing / How to review

-Open the Color Picker route.
-Verify a color is generated on load and applied to the picker.
-Click Auto Generate - color updates and codes update.
-Click Add to Palette multiple times, ensure duplicates are prevented and capacity stops at 5.
-Tap/select a palette chip, verify it highlights and the code list shown matches the color.
-Use the copy button on chips and code entries, verify clipboard behavior.
-Delete a palette item and ensure selection and counts update correctly.

I also ensured i followed the codebase patterns. 




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a color palette workflow to the Color Picker so users can auto-generate, save, inspect, copy, and manage up to 5 colors. Introduces reusable components and small UI hints; prevents duplicates and keeps the picker in sync.

- **New Features**
  - Auto-generate a color on load and via button; picker and codes stay in sync.
  - Add current color to a palette (max 5, no duplicates).
  - Selectable palette chips highlight and show that color’s code list.
  - Copy from chips and individual code entries; delete updates selection and counts.
  - New shared components: ColorChip, ColorCodeList, DeleteButton.

- **Dependencies**
  - Added @types/colorthief (dev) for TypeScript support.

<sup>Written for commit 3d0e3061dabbcc47be246692aeef0a4f981fde04. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



