### PR TITLE
feat: Add clipboard paste support to the file dropzone component and introduced a utility for MIME type matching

### DIFF
--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -64,6 +64,12 @@ export const FileDropZone = ({
         if (isSupportedMime(item.type)) {
           const file = item.getAsFile();
           if (file) {
+            if (file.size > maxSize) {
+              alert(
+                `File is too large. Please select a file smaller than ${formatFileSize(maxSize)}.`,
+              );
+              return;
+            }
             onFileSelect(file);
             break;
           }
@@ -77,7 +83,7 @@ export const FileDropZone = ({
     return () => {
       window.removeEventListener("paste", handlePaste);
     };
-  }, [])
+  }, [onFileSelect, accept, maxSize])
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,

--- a/src/components/shared/file-dropzone.tsx
+++ b/src/components/shared/file-dropzone.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useDropzone } from "react-dropzone";
 import { Upload, Loader2Icon, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { buildMimeMatcher } from "@/utils/build-mimetype-matcher";
 
 interface FileDropZoneProps {
   onFileSelect: (file: File) => void;
@@ -49,6 +50,35 @@ export const FileDropZone = ({
     [onFileSelect, maxSize],
   );
 
+  useEffect(() => {
+
+    const isSupportedMime = buildMimeMatcher(accept);
+
+    const handlePaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items
+
+      if (!items) return;
+
+      // Find the first image file in the clipboard
+      for (const item of items) {
+        if (isSupportedMime(item.type)) {
+          const file = item.getAsFile();
+          if (file) {
+            onFileSelect(file);
+            break;
+          }
+        }
+      }
+
+    };
+
+    window.addEventListener("paste", handlePaste);
+
+    return () => {
+      window.removeEventListener("paste", handlePaste);
+    };
+  }, [])
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept,
@@ -65,6 +95,7 @@ export const FileDropZone = ({
   const acceptedFormats = Object.keys(accept)
     .map((key) => key.split("/")[1]?.toUpperCase() || key)
     .join(", ");
+
 
   return (
     <div

--- a/src/utils/build-mimetype-matcher.ts
+++ b/src/utils/build-mimetype-matcher.ts
@@ -1,0 +1,18 @@
+export function buildMimeMatcher(accept: Record<string, string[]>) {
+    const exact: Set<string> = new Set();
+    const wildcards: string[] = [];
+
+    for (const key of Object.keys(accept)) {
+        if (key.endsWith('/*')) {
+            wildcards.push(key.slice(0, -2));
+        } else {
+            exact.add(key);
+        }
+    }
+
+    return (mime: string) => {
+        if (exact.has(mime)) return true;
+        const [type] = mime.split('/');
+        return wildcards.includes(type);
+    };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds clipboard paste support to FileDropZone so users can paste files directly, not just drag-and-drop. Adds size validation for pasted files and a MIME matcher utility to align paste filtering with the dropzone’s accept config.

- **New Features**
  - Paste handling: listens for paste events, filters clipboard items with accept, validates maxSize, and selects the first matching file. Cleans up the listener on unmount.
  - Utility: buildMimeMatcher supports exact types and type/* wildcards and is used to validate pasted files.

<sup>Written for commit 024e391e4c1672a7d5e8223272a38496fc0406ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

